### PR TITLE
Fix the debug handler problem and let the OrientRecord support unicode.

### DIFF
--- a/pyorient/ORecordCoder.py
+++ b/pyorient/ORecordCoder.py
@@ -85,8 +85,9 @@ class ORecordEncoder(object):
         return raw
 
     def parseValue(self, value):
-
-        if isinstance(value, str):
+        if isinstance(value, unicode):
+            ret =  u'"'+value+u'"'
+        elif isinstance(value, str):
             ret =  '"'+value+'"'
         elif isinstance(value, int):
             ret = str(value)

--- a/pyorient/OrientDB.py
+++ b/pyorient/OrientDB.py
@@ -68,9 +68,8 @@ class OrientDB(object):
     def recordcreate(self, cluster_id, record, **kwargs):
         if not isinstance(record, OrientRecord):
             record = OrientRecord(record)
-        
         parser = ORecordEncoder(record)
-        raw_record = parser.getRaw()
+        raw_record = str(parser.getRaw().encode('utf-8'))
         ret = _pyorient.recordcreate(cluster_id, raw_record, **kwargs)
 
         return ret

--- a/src/pyorientmodule.c
+++ b/src/pyorientmodule.c
@@ -136,7 +136,7 @@ void custom_debug(const char *message) {
 /*
  * set debug level module wide
  */
-static PyObject *pyorient_setDebugLevel(PyObject *self, PyObject *args) {
+static PyObject *pyorient_setDebugLevel(PyObject *self, PyObject *args, PyObject *kwargs) {
 
     int ok = PyArg_ParseTuple(args, "i", &debug_level);
     if (!ok){
@@ -150,7 +150,7 @@ static PyObject *pyorient_setDebugLevel(PyObject *self, PyObject *args) {
 /*
  * Set debug callback
  */
-static PyObject *pyorient_setLoggingCallback(PyObject *self, PyObject *args) {
+static PyObject *pyorient_setLoggingCallback(PyObject *self, PyObject *args, PyObject *kwargs) {
     PyObject *result = NULL;
     PyObject *temp;
 
@@ -723,8 +723,8 @@ static PyObject *pyorient_recordload(PyObject *self, PyObject *args, PyObject *k
 /* MODULE INIT ------------------------------------------------ */
 static PyMethodDef _pyorient_methods[] = {
 
-    { "setDebugLevel", (PyCFunction)pyorient_setDebugLevel, METH_VARARGS, NULL },
-    { "setLoggingCallback", (PyCFunction)pyorient_setLoggingCallback, METH_VARARGS, NULL },
+    { "setDebugLevel", (PyCFunction)pyorient_setDebugLevel, METH_VARARGS | METH_KEYWORDS, NULL },
+    { "setLoggingCallback", (PyCFunction)pyorient_setLoggingCallback, METH_VARARGS | METH_KEYWORDS, NULL },
 
     { "connect", (PyCFunction)pyorient_connect, METH_VARARGS, NULL },
     { "shutdown", (PyCFunction)pyorient_shutdown, METH_VARARGS | METH_KEYWORDS, NULL },


### PR DESCRIPTION
Hi, 

I'm using Orient to hosting some data, and trying to use pyorient to load the data into it.

I found out there is some bug in the logging function(say setDebugLevel or setLoggingCallback), so I fix them.

And when I loading the data up to server, I found out that all the unicode value are filtered out, and I fix that too(not so smart, just encoded the string), hope this patch will make this little library better.

Thanks.
