### PR TITLE
There is an issue with orient server connection pool

### DIFF
--- a/pyorient/exceptions.py
+++ b/pyorient/exceptions.py
@@ -17,6 +17,10 @@ class PyOrientConnectionException(PyOrientException):
     pass
 
 
+class PyOrientConnectionPoolException(PyOrientConnectionException):
+    pass
+
+
 class PyOrientDatabaseException(PyOrientException):
     pass
 

--- a/pyorient/orient.py
+++ b/pyorient/orient.py
@@ -52,7 +52,7 @@ class OrientSocket(object):
                 self._socket.close()
 
                 raise PyOrientConnectionPoolException(
-                    "Server sent empty string"
+                    "Server sent empty string", []
                 )
 
             self.protocol = struct.unpack('!h', _value)[0]


### PR DESCRIPTION
If the pool is exceeded the server sends an empty string `''`, which raises an unspecific error

`error: unpack requires a string argument of length 2`