### PR TITLE
DATETIME serialized incorrectly

### DIFF
--- a/pyorient/serialization.py
+++ b/pyorient/serialization.py
@@ -483,7 +483,7 @@ class ORecordEncoder(object):
             ret = str(value)
 
         elif isinstance(value, datetime):
-            ret = str(int(time.mktime(value.timetuple()))) + 't'
+            ret = str(int(time.mktime(value.timetuple())) * 1000) + 't'
         elif isinstance(value, date):
             ret = str(int(time.mktime(value.timetuple())) * 1000) + 'a'
         elif isinstance(value, list):


### PR DESCRIPTION
Value of datetime is being serialized incorrectly.
Eg. datetime.now() is stored as '1970-01-17 22:37:24'