### PR TITLE
change db_opened to None after db_close()

### DIFF
--- a/pyorient/messages/database.py
+++ b/pyorient/messages/database.py
@@ -205,6 +205,8 @@ class DbCloseMessage(BaseMessage):
         return super( DbCloseMessage, self ).prepare()
 
     def fetch_response(self):
+        # set database closed
+        self._orientSocket.db_opened = None
         super( DbCloseMessage, self ).close()
         return 0
 


### PR DESCRIPTION
Small change to set db_opened back to None after db_closed is called. 