### PR TITLE
Fix Python 2.7 Unicode encoding issue (#83).

### DIFF
--- a/pyorient/messages/base.py
+++ b/pyorient/messages/base.py
@@ -282,14 +282,20 @@ class BaseMessage(object):
             _content = struct.pack("!i", len(v)) + v
         elif t['type'] == STRING:
             if sys.version_info[0] >= 3:
-                if isinstance( v, str ):
+                if isinstance(v, str):
+                    v = v.encode('utf-8')
+            else:
+                if isinstance(v, unicode):
                     v = v.encode('utf-8')
             _content = struct.pack("!i", len(v)) + v
         elif t['type'] == STRINGS:
             _content = b''
             for s in v:
                 if sys.version_info[0] >= 3:
-                    if isinstance( s, str ):
+                    if isinstance(s, str):
+                        s = s.encode('utf-8')
+                else:
+                    if isinstance(s, unicode):
                         s = s.encode('utf-8')
                 _content += struct.pack("!i", len(s)) + s
 


### PR DESCRIPTION
This PR fixes problems encountered when using Unicode strings with Python 2.7 as arguments to `db_open`, `record_create`, etc. Python 3 functionality is preserved. 