### PR TITLE
Expose gremlin functionality.

### DIFF
--- a/pyorient/messages/commands.py
+++ b/pyorient/messages/commands.py
@@ -112,8 +112,10 @@ class CommandMessage(BaseMessage):
         if self._command_type == QUERY_ASYNC \
                 or self._command_type == QUERY_SYNC \
                 or self._command_type == QUERY_GREMLIN:
-            # set limit from sql string every times override the limit param
-            if ' limit ' not in self._query:
+
+            # a limit specified in a sql string should always override a
+            # limit parameter pass to prepare()
+            if ' limit ' not in self._query or self._command_type == QUERY_GREMLIN:
                 _payload_definition.append( ( FIELD_INT, self._limit ) )
             else:
                 _payload_definition.append( ( FIELD_INT, -1 ) )

--- a/pyorient/orient.py
+++ b/pyorient/orient.py
@@ -12,7 +12,7 @@ from .exceptions import PyOrientBadMethodCallException, \
     PyOrientConnectionPoolException
 
 from .constants import FIELD_SHORT, \
-    QUERY_ASYNC, QUERY_CMD, QUERY_SYNC, QUERY_SCRIPT, \
+    QUERY_ASYNC, QUERY_CMD, QUERY_GREMLIN, QUERY_SYNC, QUERY_SCRIPT, \
     SERIALIZATION_DOCUMENT2CSV, SUPPORTED_PROTOCOL
 from .utils import dlog
 
@@ -242,6 +242,10 @@ class OrientDB(object):
             .prepare(args).send().fetch_response()
 
     # DATABASE COMMANDS
+
+    def gremlin(self, *args):
+        return self.get_message("CommandMessage") \
+            .prepare(( QUERY_GREMLIN, ) + args).send().fetch_response()
 
     def command(self, *args):
         return self.get_message("CommandMessage") \

--- a/test/test_raw_messages_1.py
+++ b/test/test_raw_messages_1.py
@@ -362,6 +362,7 @@ class RawMessages_1_TestCase(unittest.TestCase):
         res = req_msg.prepare( [ QUERY_GREMLIN, "g.V.outE('followed_by')[0]" ] ) \
             .send().fetch_response()
 
+        assert len(res) == 1
         assert res[0]._rid == '#11:0'
         assert res[0]._class == 'followed_by'
         assert res[0]._version == 2

--- a/test/test_raw_messages_1.py
+++ b/test/test_raw_messages_1.py
@@ -8,7 +8,7 @@ from pyorient.messages.connection import ConnectMessage, ShutdownMessage
 from pyorient.messages.database import DbExistsMessage, DbOpenMessage, DbCreateMessage,\
  DbDropMessage, DbReloadMessage, DbCloseMessage, DbSizeMessage, DbListMessage
 from pyorient.messages.commands import CommandMessage
-from pyorient.constants import DB_TYPE_DOCUMENT, QUERY_SYNC, \
+from pyorient.constants import DB_TYPE_DOCUMENT, QUERY_SYNC, QUERY_GREMLIN, \
     STORAGE_TYPE_PLOCAL
 
 
@@ -336,6 +336,35 @@ class RawMessages_1_TestCase(unittest.TestCase):
 
         res = req_msg.prepare( [ QUERY_SYNC, "select * from followed_by limit 1" ] ) \
             .send().fetch_response()
+
+        print("%r" % res[0]._rid)
+        print("%r" % res[0]._class)
+        print("%r" % res[0]._version)
+        
+    def test_gremlin(self):
+        connection = OrientSocket( "localhost", 2424 )
+
+        print("Sid, should be -1 : %s" % connection.session_id)
+        assert connection.session_id == -1
+
+        # ##################
+
+        msg = DbOpenMessage( connection )
+
+        db_name = "GratefulDeadConcerts"
+        cluster_info = msg.prepare(
+            (db_name, "admin", "admin", DB_TYPE_DOCUMENT, "")
+        ).send().fetch_response()
+        assert len(cluster_info) != 0
+
+        req_msg = CommandMessage( connection )
+
+        res = req_msg.prepare( [ QUERY_GREMLIN, "g.V.outE('followed_by')[0]" ] ) \
+            .send().fetch_response()
+
+        assert res[0]._rid == '#11:0'
+        assert res[0]._class == 'followed_by'
+        assert res[0]._version == 2
 
         print("%r" % res[0]._rid)
         print("%r" % res[0]._class)


### PR DESCRIPTION
Not sure if the gremlin command functionality hasn't been exposed in pyorient yet because it is incomplete, but it seemed to work fine when I tried it out; this PR contains some minor tweaks that enable one to run gremlin command via `pyorient.orient.OrientDB.gremlin()`.