### PR TITLE
Update __init__.py

### DIFF
--- a/pyorient/__init__.py
+++ b/pyorient/__init__.py
@@ -5,4 +5,4 @@ from .exceptions import *
 from .types import *
 from .constants import *
 from .scripts import Scripts
-from serializations import OrientSerialization
+from .serializations import OrientSerialization


### PR DESCRIPTION
Import format fails on Python3, switch to using an explicitly relative import (like surrounding ones) to fix