### PR TITLE
Added ogm test (currently failing) and fix for datetime values.

### DIFF
--- a/pyorient/ogm/property.py
+++ b/pyorient/ogm/property.py
@@ -2,6 +2,7 @@ from .operators import Operand, ArithmeticMixin
 
 import json
 import decimal
+from datetime import datetime
 
 class Property(Operand):
     num_instances = 0 # Basis for ordering property instances
@@ -78,6 +79,8 @@ class PropertyEncoder:
     def encode(value):
         if isinstance(value, decimal.Decimal):
             return repr(str(value))
+        if isinstance(value, datetime):
+            return '"{}"'.format(value)
         return repr(value) if isinstance(value, str) else \
             value if value is not None else 'null'
 

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -1,12 +1,13 @@
 import unittest
 import decimal
 import os.path
+from datetime import datetime
 
 from pyorient.ogm import Graph, Config
 from pyorient.groovy import GroovyScripts
 
 from pyorient.ogm.declarative import declarative_node, declarative_relationship
-from pyorient.ogm.property import String, Decimal, Float, UUID
+from pyorient.ogm.property import String, DateTime, Decimal, Float, UUID
 
 from pyorient.ogm.what import expand, in_, out, distinct
 
@@ -258,3 +259,33 @@ class OGMClassTestCase(unittest.TestCase):
         else:
             assert False and 'Failed to enforce correct vertex base classes.'
 
+
+DateTimeNode = declarative_node()
+
+
+class OGMDateTimeTestCase(unittest.TestCase):
+    class DateTimeV(DateTimeNode):
+        element_type = 'datetime'
+        element_plural = 'datetime'
+
+        name = String(nullable=False, unique=True)
+        at = DateTime(nullable=False)
+
+    def setUp(self):
+        g = self.g = Graph(Config.from_url('test_datetime', 'root', 'root',
+                                           initial_drop=True))
+
+        g.create_all(DateTimeNode.registry)
+
+    def testDateTime(self):
+        g = self.g
+
+        # orientdb does not store microseconds
+        # so make sure the generated datetime has none
+        at = datetime.now().replace(microsecond=0)
+
+        g.datetime.create(name='now', at=at)
+
+        returned_dt = g.datetime.query(name='now').one()
+
+        assert returned_dt.at == at


### PR DESCRIPTION
`pyorient` currently forgets to quote datetime values sent to OrientDB. I wrote a test case that demonstrates this problematic behavior, resulting in the following output:
```
======================================================================
ERROR: testDateTime (tests.test_ogm.OGMDateTimeTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/predrag/Code/pyorient/tests/test_ogm.py", line 287, in testDateTime
    g.datetime.create(name='now', at=at)
  File "/Users/predrag/Code/pyorient/pyorient/ogm/broker.py", line 53, in create
    return self.g.create_vertex(self.element_cls, **kwargs)
  File "/Users/predrag/Code/pyorient/pyorient/ogm/graph.py", line 277, in create_vertex
    'CREATE VERTEX {}{}'.format(class_name, set_clause))[0]
  File "/Users/predrag/Code/pyorient/pyorient/orient.py", line 398, in command
    .prepare(( QUERY_CMD, ) + args).send().fetch_response()
  File "/Users/predrag/Code/pyorient/pyorient/messages/commands.py", line 145, in fetch_response
    super( CommandMessage, self ).fetch_response()
  File "/Users/predrag/Code/pyorient/pyorient/messages/base.py", line 256, in fetch_response
    self._decode_all()
  File "/Users/predrag/Code/pyorient/pyorient/messages/base.py", line 240, in _decode_all
    self._decode_header()
  File "/Users/predrag/Code/pyorient/pyorient/messages/base.py", line 192, in _decode_header
    [ exception_message.decode( 'utf8' ) ]
PyOrientSQLParsingException: com.orientechnologies.orient.core.sql.OCommandSQLParsingException - Error on parsing command at position #0: Encountered " <INTEGER_LITERAL> "14 "" at line 1, column 53.
Was expecting one of:
    <EOF> 
    ";" ...
    "," ...
    "," ...
    "," ...
    "," ...
    "," ...
    "," ...
    "," ...
    "," ...
    "," ...
----------------------------------------------------------------------
```

The change to `property.py` fixes this problem and causes the test to pass.

Please let me know what you think!

P.S.: A similar problem happens if a user passes in a `unicode` type rather than a `str` -- the result is an unquoted string due to a bug at the same location in `property.py`. If you'd like, I can open a PR for that too.