### PR TITLE
Fixed multiple-argument gremlin scripts, and datetime args in scripts.

### DIFF
--- a/pyorient/scripts.py
+++ b/pyorient/scripts.py
@@ -1,6 +1,7 @@
 from collections import namedtuple, OrderedDict
 from ast import literal_eval
 import re
+from datetime import datetime
 
 ScriptFunction = \
     namedtuple('Method', ['definition', 'signature', 'body', 'sha1'])
@@ -72,13 +73,19 @@ class Scripts(object):
                 args = {}
 
         split_body = re.split(r'([\"\'])', function.body)
+
+        replacements = {}
+        for k, v in args.items():
+            if isinstance(v, str) or isinstance(v, datetime):
+                replacements[k] = "'{}'".format(v)
+            else:
+                replacements[k] = '{}'.format(v)
+
         for i, s in enumerate(split_body):
             if i % 4 == 0:
-                for k,v in args.items():
-                    split_body[i] = re.sub(
-                        r'\b{}\b'.format(k)
-                        , '{}'.format(repr(v) if isinstance(v, str) else v)
-                        , s)
+                for k, v in replacements.items():
+                    split_body[i] = re.sub(r'\b{}\b'.format(k),
+                                           v, split_body[i])
 
         return ''.join(split_body)
 

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -109,6 +109,10 @@ def get_eaters_of(food_type) {
 def get_foods_eaten_by(animal) {
     return g.v(animal).outE('eats').inV()
 }
+
+def get_colored_eaten_foods(animal, color) {
+    return g.v(animal).outE('eats').inV().has('color', T.eq, color)
+}
 """))
 
         pea_eaters = g.gremlin('get_eaters_of', 'pea')
@@ -118,6 +122,12 @@ def get_foods_eaten_by(animal) {
         rat_cuisine = g.gremlin('get_foods_eaten_by', (rat,))
         for food in rat_cuisine:
             print(food.name, food.color) # 'pea green'
+
+        yellow_mouse_foods = g.gremlin('get_colored_eaten_foods',
+                                       (mouse, 'yellow'))
+        for food in yellow_mouse_foods:
+            print(food.name, food.color)  # 'cheese green'
+
 
 MoneyNode = declarative_node()
 MoneyRelationship = declarative_relationship()


### PR DESCRIPTION
Gremlin scripts currently have two problems:
- datetime arguments are not quoted (same problem as #122)
- scripts with multiple parameters do not correctly substitute in arguments, because successful replacements will get trampled by unsuccessful replacements -- `s` should be `split_body[i]` [here](https://github.com/mogui/pyorient/blob/c4d77f7e5bfe7d466d53da60877b74464f8c6c1f/pyorient/scripts.py#L81)

This PR provides a test (failing on pyorient 1.4.5c) and a fix.

Output of the test without the fix:
```
======================================================================
ERROR: testGraph (tests.test_ogm.OGMAnimalsTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/predrag/Code/pyorient/tests/test_ogm.py", line 127, in testGraph
    (mouse, 'yellow'))
  File "/Users/predrag/Code/pyorient/pyorient/ogm/graph.py", line 338, in gremlin
    response = self.client.gremlin(script_body)
  File "/Users/predrag/Code/pyorient/pyorient/orient.py", line 394, in gremlin
    .prepare(( QUERY_GREMLIN, ) + args).send().fetch_response()
  File "/Users/predrag/Code/pyorient/pyorient/messages/commands.py", line 145, in fetch_response
    super( CommandMessage, self ).fetch_response()
  File "/Users/predrag/Code/pyorient/pyorient/messages/base.py", line 256, in fetch_response
    self._decode_all()
  File "/Users/predrag/Code/pyorient/pyorient/messages/base.py", line 240, in _decode_all
    self._decode_header()
  File "/Users/predrag/Code/pyorient/pyorient/messages/base.py", line 192, in _decode_header
    [ exception_message.decode( 'utf8' ) ]
PyOrientCommandException: com.orientechnologies.orient.core.exception.OCommandExecutionExceptionjavax.script.ScriptExceptionjavax.script.ScriptExceptiongroovy.lang.MissingPropertyException - Error on execution of the GREMLIN scriptjavax.script.ScriptException: groovy.lang.MissingPropertyException: No such property: color for class: Script72groovy.lang.MissingPropertyException: No such property: color for class: Script72No such property: color for class: Script72
```

Hat tip [@lodrion](https://github.com/lodrion) for discovering this bug and writing the test.