### PR TITLE
Added unicode value test and a bunch of unicode quoting fixes.

### DIFF
--- a/pyorient/ogm/property.py
+++ b/pyorient/ogm/property.py
@@ -1,5 +1,6 @@
 from .operators import Operand, ArithmeticMixin
 
+import sys
 import json
 import decimal
 from datetime import datetime
@@ -79,10 +80,16 @@ class PropertyEncoder:
     def encode(value):
         if isinstance(value, decimal.Decimal):
             return repr(str(value))
-        if isinstance(value, datetime):
+        elif isinstance(value, datetime):
             return '"{}"'.format(value)
-        return repr(value) if isinstance(value, str) else \
-            value if value is not None else 'null'
+        elif isinstance(value, str):
+            return repr(value)
+        elif sys.version_info[0] < 3 and isinstance(value, unicode):
+            return repr(value.encode('utf-8'))
+        elif value is None:
+            return 'null'
+        else:
+            return value
 
 class Boolean(Property):
     pass

--- a/pyorient/ogm/query.py
+++ b/pyorient/ogm/query.py
@@ -1,5 +1,5 @@
 from .operators import Operator, RelativeOperand, Operand, ArithmeticOperation
-from .property import Property
+from .property import Property, PropertyEncoder
 from .element import GraphElement
 from .exceptions import MultipleResultsFound, NoResultFound
 from .what import What, FunctionWhat, ChainableWhat
@@ -157,6 +157,7 @@ class Query(object):
         select = self.build_select(props, where + optional_clauses)
 
         g = self._graph
+
         response = g.client.command(select)
         if response:
             # TODO Determine which other queries always take only one iteration
@@ -310,9 +311,7 @@ class Query(object):
                     left_str, ArgConverter.convert_to(ArgConverter.Value
                                                       , right, self))
             elif op is Operator.Between:
-                far_right = expression_root.operands[2]
-                if isinstance(far_right, str):
-                    far_right = repr(far_right)
+                far_right = PropertyEncoder.encode(expression_root.operands[2])
                 return '{0} BETWEEN {1} and {2}'.format(
                     left_str, right, far_right)
             elif op is Operator.Contains:
@@ -404,7 +403,7 @@ class Query(object):
     def build_wheres(self, params):
         kw_filters = params.get('kw_filters')
         kw_where = [' and '.join('{0}={1}'
-            .format(k, repr(v) if isinstance(v, str) else v)
+            .format(k, PropertyEncoder.encode(v))
                 for k,v in kw_filters.items())] if kw_filters else []
 
         filter_exp = params.get('filter')

--- a/pyorient/ogm/query_utils.py
+++ b/pyorient/ogm/query_utils.py
@@ -1,4 +1,4 @@
-from .property import Property
+from .property import Property, PropertyEncoder
 from .element import GraphElement
 
 from .what import What
@@ -16,7 +16,7 @@ class ArgConverter(object):
     @staticmethod
     def convert_to(conversion, arg, for_query):
         if conversion is ArgConverter.Label:
-            return '{}'.format(repr(arg) if isinstance(arg, str) else arg)
+            return '{}'.format(PropertyEncoder.encode(arg))
         elif conversion is ArgConverter.Expression:
             if isinstance(arg, LogicalConnective):
                 return '\'{}\''.format(for_query.filter_string(arg))
@@ -46,7 +46,7 @@ class ArgConverter(object):
             elif isinstance(arg, What):
                 return for_query.build_what(arg)
             else:
-                return repr(arg) if isinstance(arg, str) else str(arg)
+                return PropertyEncoder.encode(arg)
         elif conversion is ArgConverter.Boolean:
             if isinstance(arg, What):
                 return for_query.build_what(arg)

--- a/pyorient/scripts.py
+++ b/pyorient/scripts.py
@@ -2,6 +2,7 @@ from collections import namedtuple, OrderedDict
 from ast import literal_eval
 import re
 from datetime import datetime
+import sys
 
 ScriptFunction = \
     namedtuple('Method', ['definition', 'signature', 'body', 'sha1'])
@@ -78,6 +79,8 @@ class Scripts(object):
         for k, v in args.items():
             if isinstance(v, str) or isinstance(v, datetime):
                 replacements[k] = "'{}'".format(v)
+            elif sys.version_info[0] < 3 and isinstance(v, unicode):
+                replacements[k] = repr(v.encode('utf-8'))
             else:
                 replacements[k] = '{}'.format(v)
 

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -299,3 +299,33 @@ class OGMDateTimeTestCase(unittest.TestCase):
         returned_dt = g.datetime.query(name='now').one()
 
         assert returned_dt.at == at
+
+
+UnicodeNode = declarative_node()
+
+
+class OGMUnicodeTestCase(unittest.TestCase):
+    class UnicodeV(UnicodeNode):
+        element_type = 'unicode'
+        element_plural = 'unicode'
+
+        name = String(nullable=False, unique=True)
+        value = String(nullable=False)
+
+    def setUp(self):
+        g = self.g = Graph(Config.from_url('test_unicode', 'root', 'root',
+                                           initial_drop=True))
+
+        g.create_all(UnicodeNode.registry)
+
+    def testUnicode(self):
+        g = self.g
+
+        name = 'unicode test'
+        value = u'unicode value'
+
+        g.unicode.create(name=name, value=value)
+
+        returned_v = g.unicode.query(name=name).one()
+
+        assert returned_v.value == value


### PR DESCRIPTION
If an ASCII-encodable `unicode` value is passed in as an argument for a `String` property, `pyorient` fails to quote it, generating queries like this one:
```
CREATE VERTEX unicode SET name='unicode test',value=unicode value
```

This is obviously not legal OrientDB SQL, and it caused parsing errors:
```
======================================================================
ERROR: testUnicode (tests.test_ogm.OGMUnicodeTestCase)
----------------------------------------------------------------------
...
PyOrientSQLParsingException: com.orientechnologies.orient.core.sql.OCommandSQLParsingException - Error on parsing command at position #0: Encountered " <IDENTIFIER> "value "" at line 1, column 61.
Was expecting one of:
    <EOF> 
...
----------------------------------------------------------------------
```

This PR partially fixes the problem -- general Unicode still doesn't work due to ASCII conversion issues, but ASCII-encodable `unicode` values work fine.