### PR TITLE
Added a fix for the URL parsing in ogm/config.

### DIFF
--- a/pyorient/ogm/config.py
+++ b/pyorient/ogm/config.py
@@ -26,18 +26,16 @@ class Config(object):
 
     @classmethod
     def from_url(cls, url, user, cred, initial_drop=False):
-        url_exp = re.compile(r'^(\w+:)(\/\/)?(.*)')
+        url_exp = re.compile(r'^(\w+:\/\/)?(.*)')
         url_match = url_exp.match(url)
-        if url_match:
-            url = url_match.group(1) + (url_match.group(2) or '//') \
-                    + url_match.group(3)
-        else:
+        if not url_match.group(1):
             if '/' in url:
                 url = 'plocal://' + url
             else:
                 url = 'memory://' + url
 
         url_parts = urlparse(url)
+
         if url_parts.path:
             db_name = os.path.basename(url_parts.path)
             return cls(url_parts.hostname, url_parts.port, user, cred, db_name

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -364,3 +364,19 @@ class OGMUnicodeTestCase(unittest.TestCase):
         returned_v = g.unicode.query(name=name).one()
 
         assert returned_v.value == value
+
+
+class OGMTestCase(unittest.TestCase):
+    def testConfigs(self):
+        configs = [
+            'localhost:2424/test_config1',
+            'localhost/test_config2',
+            'plocal://localhost/test_config3',
+            'plocal://localhost:2424/test_config4',
+            'memory://localhost/test_config5',
+            'memory://localhost:2424/test_config6',
+        ]
+
+        for conf in configs:
+            # the following line should not raise errors
+            Graph(Config.from_url(conf, 'root', 'root', initial_drop=True))


### PR DESCRIPTION
Config mis-parsed URL strings, transforming URLs such as `localhost:2424/db_name` to:
```
ParseResult(scheme='localhost', netloc='', path='2424/db_name', params='', query='', fragment='')
```

This obviously results in a failure to connect to the DB.