### PR TITLE
fix spelling parse_value

### DIFF
--- a/pyorient/serializations.py
+++ b/pyorient/serializations.py
@@ -136,7 +136,7 @@ class OrientSerializationCSV(object):
             try:
                 ret = "[" + ','.join(
                     map(
-                        lambda elem: self.parse_value(type(value[0])(elem))
+                        lambda elem: self._parse_value(type(value[0])(elem))
                         if not isinstance(value[0], OrientRecordLink)
                         else elem.get_hash(),
                         value
@@ -145,7 +145,7 @@ class OrientSerializationCSV(object):
                 raise Exception("wrong type commistion")
         elif isinstance(value, dict):
             ret = "{" + ','.join(map(
-                lambda elem: '"' + elem + '":' + self.parse_value(value[elem]),
+                lambda elem: '"' + elem + '":' + self._parse_value(value[elem]),
                 value)) + '}'
         elif isinstance(value, OrientRecord):
             ret = "(" + self.__encode(value) + ")"


### PR DESCRIPTION
Simple fix for ``AttributeError: 'OrientSerializationCSV' object has no attribute 'parse_value'``