### PR TITLE
changed generic Exception to PyOrientNullRecordException in BaseMessage

### DIFF
--- a/pyorient/exceptions.py
+++ b/pyorient/exceptions.py
@@ -74,3 +74,7 @@ class PyOrientWrongProtocolVersionException(PyOrientException):
 
 class PyOrientSerializationException(PyOrientException):
     pass
+
+
+class PyOrientNullRecordException(PyOrientException):
+    pass

--- a/pyorient/messages/base.py
+++ b/pyorient/messages/base.py
@@ -4,7 +4,7 @@ import struct
 import sys
 
 from ..exceptions import PyOrientBadMethodCallException, \
-    PyOrientCommandException
+    PyOrientCommandException, PyOrientNullRecordException
 from ..otypes import OrientRecord, OrientRecordLink
 
 from ..hexdump import hexdump
@@ -448,13 +448,13 @@ class BaseMessage(object):
             (0:short)(record-type:byte)(cluster-id:short)
             (cluster-position:long)(record-version:int)(record-content:bytes)
 
-        :raise: Exception
+        :raise: PyOrientNullRecordException
         :return: OrientRecordLink,OrientRecord
         """
         marker = self._decode_field( FIELD_SHORT )  # marker
 
         if marker is -2:
-            raise Exception('NULL Record')
+            raise PyOrientNullRecordException('NULL Record', [])
         elif marker is -3:
             res = OrientRecordLink( self._decode_field( FIELD_TYPE_LINK ) )
         else:


### PR DESCRIPTION
With PyOrientNullRecordException instead of generic exception catch in client application will be a lot easier ;)