### PR TITLE
Fixed a non-existent variable reference when creating edges with kwargs.

### DIFF
--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -342,7 +342,7 @@ class Graph(object):
         class_name = edge_cls.registry_name
 
         if kwargs:
-            db_props = self.props_to_db(vertex_cls, kwargs)
+            db_props = self.props_to_db(edge_cls, kwargs)
             set_clause = u' SET {}'.format(
                 u','.join(u'{}={}'.format(k,PropertyEncoder.encode(v))
                          for k,v in db_props.items()))

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -30,6 +30,7 @@ class Food(AnimalsNode):
 
 class Eats(AnimalsRelationship):
     label = 'eats'
+    modifier = String()
 
 class OGMAnimalsTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -73,9 +74,11 @@ class OGMAnimalsTestCase(unittest.TestCase):
 
         assert queried_pea == pea
 
-        rat_eats_pea = g.eats.create(queried_rat, queried_pea)
+        rat_eats_pea = g.eats.create(queried_rat, queried_pea, modifier='lots')
         mouse_eats_pea = g.eats.create(mouse, pea)
         mouse_eats_cheese = Eats.objects.create(mouse, cheese)
+
+        assert rat_eats_pea.modifier == 'lots'
 
         eaters = g.in_(Food, Eats)
         assert rat in eaters


### PR DESCRIPTION
Fixes the following error when running the added testcase:
```
File ".../pyorient/ogm/graph.py", line 345, in create_edge_command
  db_props = self.props_to_db(vertex_cls, kwargs)
NameError: global name 'vertex_cls' is not defined
```