### PR TITLE
Faster edge queries

### DIFF
--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -467,7 +467,7 @@ class Graph(object):
         :param from_to: Vertex id, class, or class name
         :param edge_classes: Filter by these edges
         """
-        records = self.client.query('SELECT EXPAND( both({0}) )FROM {1}'
+        records = self.client.query('SELECT EXPAND( both({0}) ) FROM {1}'
             .format(','.join(Graph.coerce_class_names_to_quoted(edge_classes))
                     , self.coerce_class_names(from_to)), -1)
         return [self.vertex_from_record(v) for v in records] \

--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -407,10 +407,10 @@ class Graph(object):
         :param from_: Vertex id, class, or class name
         :param edge_classes: Filter by these edges
         """
-        records = self.client.command('SELECT outE({0}) FROM {1}'
-            .format(','.join(self.coerce_class_names(edge_classes))
-                    , self.coerce_class_names(from_)))
-        return [self.get_edge(e) for e in records[0].oRecordData['outE']] \
+        records = self.client.query('SELECT EXPAND( outE({0}) ) FROM {1}'
+            .format(','.join(Graph.coerce_class_names_to_quoted(edge_classes))
+                    , self.coerce_class_names(from_)), -1)
+        return [self.edge_from_record(r) for r in records] \
             if records else []
 
     def inE(self, to, *edge_classes):
@@ -419,10 +419,10 @@ class Graph(object):
         :param to: Vertex id, class, or class name
         :param edge_classes: Filter by these edges
         """
-        records = self.client.command('SELECT inE({0}) FROM {1}'
-            .format(','.join(self.coerce_class_names(edge_classes))
-                    , self.coerce_class_names(to)))
-        return [self.get_edge(e) for e in records[0].oRecordData['inE']] \
+        records = self.client.query('SELECT EXPAND( inE({0}) ) FROM {1}'
+            .format(','.join(Graph.coerce_class_names_to_quoted(edge_classes))
+                    , self.coerce_class_names(to)), -1)
+        return [self.edge_from_record(r) for r in records] \
             if records else []
 
     def bothE(self, from_to, *edge_classes):
@@ -431,10 +431,10 @@ class Graph(object):
         :param from_to: Vertex id, class, or class name
         :param edge_classes: Filter by these edges
         """
-        records = self.client.command('SELECT bothE({0}) FROM {1}'
-            .format(','.join(self.coerce_class_names(edge_classes))
-                    , self.coerce_class_names(from_to)))
-        return [self.get_edge(e) for e in records[0].oRecordData['bothE']] \
+        records = self.client.query('SELECT EXPAND( bothE({0}) ) FROM {1}'
+            .format(','.join(Graph.coerce_class_names_to_quoted(edge_classes))
+                    , self.coerce_class_names(from_to)), -1)
+        return [self.edge_from_record(r) for r in records] \
             if records else []
 
     def out(self, from_, *edge_classes):
@@ -443,10 +443,10 @@ class Graph(object):
         :param from_: Vertex id, class, or class name
         :param edge_classes: Filter by these edges
         """
-        records = self.client.command('SELECT out({0}) FROM {1}'
-            .format(','.join(self.coerce_class_names(edge_classes))
-                    , self.coerce_class_names(from_)))
-        return [self.get_vertex(v) for v in records[0].oRecordData['out']] \
+        records = self.client.query('SELECT EXPAND( out({0}) ) FROM {1}'
+            .format(','.join(Graph.coerce_class_names_to_quoted(edge_classes))
+                    , self.coerce_class_names(from_)), -1)
+        return [self.vertex_from_record(v) for v in records] \
             if records else []
 
     def in_(self, to, *edge_classes):
@@ -455,10 +455,10 @@ class Graph(object):
         :param to: Vertex id, class, or class name
         :param edge_classes: Filter by these edges
         """
-        records = self.client.command('SELECT in({0}) FROM {1}'
-            .format(','.join(self.coerce_class_names(edge_classes))
-                    , self.coerce_class_names(to)))
-        return [self.get_vertex(v) for v in records[0].oRecordData['in']] \
+        records = self.client.query('SELECT EXPAND( in({0}) ) FROM {1}'
+            .format(','.join(Graph.coerce_class_names_to_quoted(edge_classes))
+                    , self.coerce_class_names(to)), -1)
+        return [self.vertex_from_record(v) for v in records] \
             if records else []
 
     def both(self, from_to, *edge_classes):
@@ -467,10 +467,10 @@ class Graph(object):
         :param from_to: Vertex id, class, or class name
         :param edge_classes: Filter by these edges
         """
-        records = self.client.command('SELECT both({0}) FROM {1}'
-            .format(','.join(self.coerce_class_names(edge_classes))
-                    , self.coerce_class_names(from_to)))
-        return [self.get_vertex(v) for v in records[0].oRecordData['both']] \
+        records = self.client.query('SELECT EXPAND( both({0}) )FROM {1}'
+            .format(','.join(Graph.coerce_class_names_to_quoted(edge_classes))
+                    , self.coerce_class_names(from_to)), -1)
+        return [self.vertex_from_record(v) for v in records] \
             if records else []
 
     # The following mostly intended for internal use

--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -611,6 +611,12 @@ class Graph(object):
             if hasattr(classes, '__iter__') and not isinstance(classes, str) \
             else getattr(classes, 'registry_name', classes)
 
+    @staticmethod
+    def coerce_class_names_to_quoted(classes):
+        """Get the quoted class name(s) for vertexes/edges. Useful when passing them to some operators"""
+        names = Graph.coerce_class_names(classes)
+        return [repr(name) for name in names] if names else []
+
     def init_broker_for_class(self, cls):
         broker = get_broker(cls)
         if broker:

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -59,6 +59,8 @@ class OGMAnimalsTestCase(unittest.TestCase):
 
         queried_mouse = g.query(mouse).one()
         assert mouse == queried_mouse
+        assert mouse == g.get_vertex(mouse._id)
+        assert mouse == g.get_element(mouse._id)
 
         try:
             rat2 = g.animals.create(name='rat', specie='rodent')
@@ -79,6 +81,8 @@ class OGMAnimalsTestCase(unittest.TestCase):
         mouse_eats_cheese = Eats.objects.create(mouse, cheese)
 
         assert rat_eats_pea.modifier == 'lots'
+        assert rat_eats_pea == g.get_edge(rat_eats_pea._id)
+        assert rat_eats_pea == g.get_element(rat_eats_pea._id)
 
         eaters = g.in_(Food, Eats)
         assert rat in eaters


### PR DESCRIPTION
This uses a single query to fetch connected edges and vertices, rather than a linear number of queries, one per element. This is noticeably faster even on moderately-sized graphs running on the local machine (100s of nodes/edges --> 4s to 0.5s).