### PR TITLE
Checking socket validity on write to detect broken connection.

### DIFF
--- a/pyorient/orient.py
+++ b/pyorient/orient.py
@@ -92,10 +92,25 @@ class OrientSocket(object):
         self.connected = False
 
     def write(self, buff):
-        count = 0
-        while count < len(buff):
-            count += self._socket.send(buff[count:])
-        return count
+        # This is a trick to detect server disconnection
+        # or broken line issues because of
+        """:see: https://docs.python.org/2/howto/sockets.html#when-sockets-die """
+
+        try:
+            _, ready_to_write, in_error = select.select(
+                [], [self._socket], [self._socket], 1)
+        except select.error as e:
+            self.connected = False
+            self._socket.close()
+            raise e
+
+        if not in_error and ready_to_write:
+            self._socket.sendall(buff)
+            return len(buff)
+        else:
+            self.connected = False
+            self._socket.close()
+            raise PyOrientConnectionException("Socket error", [])
 
     # The man page for recv says: The receive calls normally return
     #   any data available, up to the requested amount, rather than waiting


### PR DESCRIPTION
This attempts to fix an issue I observed in the project I am working on. If my server remains idle for a long time, and then gets a request, its db connection seems to have died but the socket is not marked closed. The subsequent write to the socket hangs forever, and takes my server down with it.