### PR TITLE
Fixed unicode special character representation.

### DIFF
--- a/pyorient/ogm/property.py
+++ b/pyorient/ogm/property.py
@@ -1,5 +1,6 @@
 from .operators import Operand, ArithmeticMixin
 
+import json
 import sys
 import decimal
 import datetime
@@ -83,9 +84,12 @@ class PropertyEncoder:
         elif isinstance(value, datetime.datetime) or isinstance(value, datetime.date):
             return u'"{}"'.format(value)
         elif isinstance(value, str):
-            return repr(value)
+            # it just so happens that JSON in ASCII mode has the same limitations
+            # and escape sequences as what we need: \u00c5 vs \xc5 representation,
+            # quote escaping etc.
+            return json.dumps(value)
         elif sys.version_info[0] < 3 and isinstance(value, unicode):
-            return u'"{}"'.format(value.replace('"', '\\"'))
+            return json.dumps(value)
         elif value is None:
             return 'null'
         elif isinstance(value, list) or isinstance(value, set):

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -409,18 +409,19 @@ class OGMUnicodeTestCase(unittest.TestCase):
     def testUnicode(self):
         g = self.g
 
-        name = 'unicode test'
+        data = [
+            (u'general_unicode', u'unicode value\u2017\u00c5'),
+            (u'special chars: single quote', u'\''),
+            (u'special chars: quote', u'"'),
+            (u'special chars: new line', u'\n'),
+            (u'special chars: tab', u'\t'),
+            (u'multiple special chars', u'\'"\n\t'),
+        ]
 
-        # \u2017 = Double Low Line
-        # \u00c5 = Latin Capital Letter A With Ring Above
-        #          significant because python would like to represent this
-        #          as \xc5 rather than \u00c5, which OrientDB doesn't support
-        value = u'unicode value\u2017\u00c5'
-
-        g.unicode.create(name=name, value=value)
-
-        returned_v = g.unicode.query(name=name).one()
-        assert to_unicode(returned_v.value) == value
+        for name, value in data:
+            g.unicode.create(name=name, value=value)
+            returned_v = g.unicode.query(name=name).one()
+            assert to_unicode(returned_v.value) == value
 
     def testCommandEncoding(self):
         g = self.g


### PR DESCRIPTION
Closes #146, as well as an unrelated bug preventing newline characters being used in Unicode strings in Python 2.