### PR TITLE
Sanitizing property names in queries and creation commands.

### DIFF
--- a/pyorient/ogm/query.py
+++ b/pyorient/ogm/query.py
@@ -316,7 +316,7 @@ class Query(object):
                     left_str, ArgConverter.convert_to(ArgConverter.Value
                                                       , right, self))
             elif op is Operator.Between:
-                far_right = PropertyEncoder.encode(expression_root.operands[2])
+                far_right = PropertyEncoder.encode_value(expression_root.operands[2])
                 return u'{0} BETWEEN {1} and {2}'.format(
                     left_str, right, far_right)
             elif op is Operator.Contains:
@@ -325,7 +325,7 @@ class Query(object):
                         left_str, self.filter_string(right))
                 else:
                     return u'{} in {}'.format(
-                        PropertyEncoder.encode(right), left_str)
+                        PropertyEncoder.encode_value(right), left_str)
             elif op is Operator.EndsWith:
                 return u'{0} like \'%{1}\''.format(left_str, right)
             elif op is Operator.Is:
@@ -412,7 +412,7 @@ class Query(object):
     def build_wheres(self, params):
         kw_filters = params.get('kw_filters')
         kw_where = [u' and '.join(u'{0}={1}'
-            .format(k, PropertyEncoder.encode(v))
+            .format(PropertyEncoder.encode_name(k), PropertyEncoder.encode_value(v))
                 for k,v in kw_filters.items())] if kw_filters else []
 
         filter_exp = params.get('filter')

--- a/pyorient/ogm/query_utils.py
+++ b/pyorient/ogm/query_utils.py
@@ -16,7 +16,7 @@ class ArgConverter(object):
     @staticmethod
     def convert_to(conversion, arg, for_query):
         if conversion is ArgConverter.Label:
-            return '{}'.format(PropertyEncoder.encode(arg))
+            return '{}'.format(PropertyEncoder.encode_value(arg))
         elif conversion is ArgConverter.Expression:
             if isinstance(arg, LogicalConnective):
                 return '\'{}\''.format(for_query.filter_string(arg))
@@ -46,7 +46,7 @@ class ArgConverter(object):
             elif isinstance(arg, What):
                 return for_query.build_what(arg)
             else:
-                return PropertyEncoder.encode(arg)
+                return PropertyEncoder.encode_value(arg)
         elif conversion is ArgConverter.Boolean:
             if isinstance(arg, What):
                 return for_query.build_what(arg)

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -66,6 +66,14 @@ class OGMAnimalsTestCase(OGMAnimalsTestCaseBase):
 
         assert rat == queried_rat
 
+        invalid_query_args = {'name': 'rat', 'name="rat" OR 1': 1}
+        try:
+            g.animals.query(**invalid_query_args).all()
+        except:
+            pass
+        else:
+            assert False and 'Invalid params did not raise an exception!'
+
         queried_mouse = g.query(mouse).one()
         assert mouse == queried_mouse
         assert mouse == g.get_vertex(mouse._id)


### PR DESCRIPTION
In private discussion with @mogui we decided to resolve #169 via a pull request. The security issue was a SQL injection attack vector, exploitable in one location and potentially a few more, that allowed an attacker to change the `WHERE` clause in a query and cause it to return unexpected results. Here is an example query:

```
rat = g.animals.create(name='rat', specie='rodent')
mouse = g.animals.create(name='mouse', specie='rodent')

args = {'name': 'rat', 'name="rat" OR 1': 1}
res = g.animals.query(**args).all()
# Command: SELECT FROM animal WHERE name='rat' and name="rat" OR 1=1
#   Expected result: [
#        ('name': 'rat', 'specie': 'rodent')
#   ]
#   Actual result: [
#        ('name': 'rat', 'specie': 'rodent'),
#        ('name': 'mouse', 'specie': 'rodent')
#   ]
```

`graph.create_vertex` and `graph.create_edge` also do similar processing of unsanitized kwargs, but it's masked by the call to `props_to_db` so they are currently not exploitable, as far as I could determine.

This pull request resolves the problem by sanitizing kwarg arguments to the affected functions. Ideally, it would be merged immediately after #170, which fixes a bug where a newline character in a string field will unexpectedly terminate the query and cause an exception.

Thanks to the maintainers of this repository for promptly acting on my bug report!