### PR TITLE
Allow sanitising of batch variable names.

### DIFF
--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -188,8 +188,10 @@ class Graph(object):
 
                 if is_edge:
                     props['label'] = class_name
+                    props['registry_name'] = class_name
                 else:
                     if auto_plural:
+                        props['element_plural'] = class_name
                         props['registry_plural'] = class_name
                     props['element_type'] = class_name
 
@@ -449,7 +451,7 @@ class Graph(object):
         return Query(self, (first_entity,) + entities)
 
     def batch(self, isolation_level=Batch.READ_COMMITTED):
-        return Batch(self)
+        return Batch(self, isolation_level)
 
     def gremlin(self, script, args=None, namespace=None):
         script_body = self.scripts.script_body(script, args, namespace)

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -152,7 +152,7 @@ def get_colored_eaten_foods(animal, color) {
         batch['zombie'] = batch.animals.create(name='zombie',specie='undead')
         batch['brains'] = batch.foods.create(name='brains', color='grey')
         # Retry up to twenty times
-        batch[::20] = batch.eats.create(batch[:'zombie'], batch[:'brains'])
+        batch[:] = batch.eats.create(batch[:'zombie'], batch[:'brains']).retry(20)
 
         batch['unicorn'] = batch.animals.create(name='unicorn', specie='mythical')
         batch['unknown'] = batch.foods.create(name='unknown', color='rainbow')


### PR DESCRIPTION
I only fixed the merge conflict between `develop` and #139. I'm not convinced that the name cleaning approach in batch.py is the right way to go though -- it allows sanitization to be turned off, silently replaces invalid chars rather than throwing exceptions, and might itself be vulnerable to SQL injection. It's certainly better than not having any sanitization whatsoever (the current state), but I think it needs more work before I'd consider it production-ready.