### PR TITLE
Do not wrap special methods in OrientDB.__getattr__

### DIFF
--- a/pyorient/orient.py
+++ b/pyorient/orient.py
@@ -229,6 +229,10 @@ class OrientDB(object):
 
     def __getattr__(self, item):
 
+        # No special handling for private attributes/methods.
+        if item.startswith("_"):
+            return super(OrientDB, self).__getattr__(item)
+
         _names = "".join( [i.capitalize() for i in item.split('_')] )
         _Message = self.get_message(_names + "Message")
 


### PR DESCRIPTION
There are special cases when `__getattr__` wrapping doesn't work as expected. For example, IPython access `__members__` and `__methods__` attributes on the object during autocompletion. These attributes do not exist in the newer Python versions so `__getattr__` gets called which tries to find a proper message. During wrapping `get_message` is called and if message doesn't exists (in this case it doesn't) connection is silently closed. It took me a while to figure out what was going on. 

This PR will make sure that if some private method/attribute is referenced a super implementation gets called which, by default, throws `AttributeError`.

IMHO `__getattr__` should never change the state of the object. 