### PR TITLE
If the element instance attribute resolves to property, do not return it

### DIFF
--- a/pyorient/ogm/element.py
+++ b/pyorient/ogm/element.py
@@ -36,7 +36,12 @@ class GraphElement(object):
         try:
             return super(GraphElement, self).__getattribute__('_props')[key]
         except:
-            return super(GraphElement, self).__getattribute__(key)
+            attr = super(GraphElement, self).__getattribute__(key)
+            # Make sure to never return properties as instance attributes
+            if isinstance(attr, Property):
+                return None
+            else:
+                return attr
 
     def __eq__(self, other):
         return type(self) is type(other) and \

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -692,3 +692,21 @@ class OGMTestInheritance(unittest.TestCase):
         pentium = g.x86cpu.create(name='Pentium', version=6)
         self.assertEquals('Pentium', pentium.name)
         self.assertEquals(6, pentium.version)
+
+class OGMTestNullProperties(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(OGMTestNullProperties, self).__init__(*args, **kwargs)
+        self.g = None
+
+    def setUp(self):
+        g = self.g = Graph(Config.from_url('hardware', 'root', 'root'
+                                           , initial_drop=True))
+
+        g.create_all(HardwareNode.registry)
+        g.create_all(HardwareRelationship.registry)
+
+    def testInheritance(self):
+        g = self.g
+        pentium = g.x86cpu.create(name='Pentium')
+        loaded_pentium = g.get_vertex(pentium._id)
+        self.assertIsNone(loaded_pentium.version)


### PR DESCRIPTION
This fixes a bug where if an element exists in the schema, but does not exist in the database, accessing it returns the underlying `Property` object rather than `None`.