### PR TITLE
Read custom class properties

### DIFF
--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -182,6 +182,8 @@ class Graph(object):
             is_edge = bases and bases[0].decl_type == DeclarativeType.Edge
             props.update(extract_properties(class_def['properties'], is_edge))
 
+            props['class_fields'] = class_def.get('customFields', None) or {}
+
             if bases:
                 # Create class for the graph type
                 props['decl_type'] = bases[0].decl_type


### PR DESCRIPTION
OrientDB supports class-level properties, but these are currently not read by `pyorient`. This PR allows users to see and read these properties.