### PR TITLE
Sanitize operators

### DIFF
--- a/pyorient/ogm/query.py
+++ b/pyorient/ogm/query.py
@@ -160,8 +160,6 @@ class Query(object):
 
         g = self._graph
 
-        print('SELECTED:', select)
-
         response = g.client.command(select)
         if response:
             # TODO Determine which other queries always take only one iteration

--- a/pyorient/ogm/query.py
+++ b/pyorient/ogm/query.py
@@ -160,6 +160,8 @@ class Query(object):
 
         g = self._graph
 
+        print('SELECTED:', select)
+
         response = g.client.command(select)
         if response:
             # TODO Determine which other queries always take only one iteration
@@ -318,7 +320,7 @@ class Query(object):
             elif op is Operator.Between:
                 far_right = PropertyEncoder.encode_value(expression_root.operands[2])
                 return u'{0} BETWEEN {1} and {2}'.format(
-                    left_str, right, far_right)
+                    left_str, PropertyEncoder.encode_value(right), far_right)
             elif op is Operator.Contains:
                 if isinstance(right, LogicalConnective):
                     return u'{0} contains({1})'.format(
@@ -327,19 +329,19 @@ class Query(object):
                     return u'{} in {}'.format(
                         PropertyEncoder.encode_value(right), left_str)
             elif op is Operator.EndsWith:
-                return u'{0} like \'%{1}\''.format(left_str, right)
+                return u'{0} like {1}'.format(left_str, PropertyEncoder.encode_value('%' + right))
             elif op is Operator.Is:
                 if not right: # :)
                     return '{0} is null'.format(left_str)
             elif op is Operator.Like:
-                return u'{0} like \'{1}\''.format(
-                    left_str, right)
+                return u'{0} like {1}'.format(
+                    left_str, PropertyEncoder.encode_value(right))
             elif op is Operator.Matches:
-                return u'{0} matches \'{1}\''.format(
-                    left_str, right)
+                return u'{0} matches {1}'.format(
+                    left_str, PropertyEncoder.encode_value(right))
             elif op is Operator.StartsWith:
-                return u'{0} like \'{1}%\''.format(
-                    left_str, right)
+                return u'{0} like {1}'.format(
+                    left_str, PropertyEncoder.encode_value(right + '%'))
         else:
             return u'{0} {1} {2}'.format(
                 self.filter_string(left)

--- a/pyorient/ogm/query.py
+++ b/pyorient/ogm/query.py
@@ -342,6 +342,8 @@ class Query(object):
             elif op is Operator.StartsWith:
                 return u'{0} like {1}'.format(
                     left_str, PropertyEncoder.encode_value(right + '%'))
+            else:
+                raise AssertionError('Unhandled Operator type: {}'.format(op))
         else:
             return u'{0} {1} {2}'.format(
                 self.filter_string(left)


### PR DESCRIPTION
On March 28th 2015, I discovered and reported five SQL injection vulnerabilities to the owners of this repository. In private discussion, we decided to settle the problem via this pull request that will be merged as quickly as possible, to minimize the possible security impact.

Here is the summary of the five vulnerabilities:

- The LIKE operator argument isn't sanitized.
```
> graph.query(Region).filter(Region.name.like("United States' or 'a'='a")).all()
SELECT statement: SELECT FROM Region WHERE name like 'United States' or 'a'='a'
```

- The BETWEEN operator's first input isn't quoted (for strings) or sanitized
```
> graph.query(Region).filter(Region.name.between('United States" or "a"="a', 'zzzz" or "a"="a')).all()
SELECT statement: SELECT FROM Region WHERE name BETWEEN United States" or "a"="a and "zzzz\" or \"a\"=\"a"
```

- The MATCHES argument isn't sanitized.
```
> graph.query(Region).filter(Region.name.matches("United States' OR 'a'='a")).all()
SELECT statement: SELECT FROM Region WHERE name matches 'United States' OR 'a'='a'
```

- The STARTSWITH argument isn't sanitized.
```
> graph.query(Region).filter(Region.name.startswith("United States' OR 'a%'='a")).all 
SELECT statement: SELECT FROM Region WHERE name like 'United States' OR 'a%'='a%'
```

- The ENDSWITH argument isn't sanitized.
```
> graph.query(Region).filter(Region.name.endswith("United States' OR 'a'='a")).all 
SELECT statement: SELECT FROM Region WHERE name like '%United States' OR 'a'='a'
```

This pull request addresses all these issues.