### PR TITLE
Add abstract field to class objects

### DIFF
--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -183,7 +183,6 @@ class Graph(object):
             props.update(extract_properties(class_def['properties'], is_edge))
 
             props['class_fields'] = class_def.get('customFields', None) or {}
-            clusters = class_def.get('clusterIds', None) or []
             props['abstract'] = class_def.get('abstract', False)
 
             if bases:

--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -184,7 +184,7 @@ class Graph(object):
 
             props['class_fields'] = class_def.get('customFields', None) or {}
             clusters = class_def.get('clusterIds', None) or []
-            props['is_abstract'] = (clusters == [-1])
+            props['abstract'] = class_def.get('abstract', False)
 
             if bases:
                 # Create class for the graph type

--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -183,6 +183,8 @@ class Graph(object):
             props.update(extract_properties(class_def['properties'], is_edge))
 
             props['class_fields'] = class_def.get('customFields', None) or {}
+            clusters = class_def.get('clusterIds', None) or []
+            props['is_abstract'] = (clusters == [-1])
 
             if bases:
                 # Create class for the graph type

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -807,5 +807,5 @@ class OGMTestAbstractField(unittest.TestCase):
 
         database_registry = g.build_mapping(
             declarative_node(), declarative_relationship(), auto_plural=True)
-        self.assertTrue(database_registry['AbstractClass'].is_abstract)
-        self.assertFalse(database_registry['ConcreteClass'].is_abstract)
+        self.assertTrue(database_registry['AbstractClass'].abstract)
+        self.assertFalse(database_registry['ConcreteClass'].abstract)

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -789,3 +789,23 @@ class OGMTestClassField(unittest.TestCase):
         self.assertEquals(
             {'test_field_1': 'test string two'},
             g.registry['classfieldedge'].class_fields)
+
+
+class OGMTestAbstractField(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super(OGMTestAbstractField, self).__init__(*args, **kwargs)
+        self.g = None
+
+    def setUp(self):
+        g = self.g = Graph(Config.from_url('abstract_classes', 'root', 'root'
+                                           , initial_drop=True))
+        g.client.command('CREATE CLASS AbstractClass EXTENDS V ABSTRACT')
+        g.client.command('CREATE CLASS ConcreteClass EXTENDS V')
+
+    def testAbstractFlag(self):
+        g = self.g
+
+        database_registry = g.build_mapping(
+            declarative_node(), declarative_relationship(), auto_plural=True)
+        self.assertTrue(database_registry['AbstractClass'].is_abstract)
+        self.assertFalse(database_registry['ConcreteClass'].is_abstract)


### PR DESCRIPTION
This allows us to check class objects from the registry for abstractness, since pyorient (correctly) loads both abstract and non-abstract classes from the OrientDB schema.