### PR TITLE
if server protocol not supported use SUPPORTED_PROTOCOL

### DIFF
--- a/pyorient/messages/base.py
+++ b/pyorient/messages/base.py
@@ -141,7 +141,10 @@ class BaseMessage(object):
 
     def get_protocol(self):
         if self._protocol < 0:
-            self._protocol = self._orientSocket.protocol
+            if SUPPORTED_PROTOCOL < self._orientSocket.protocol:
+                self._protocol = SUPPORTED_PROTOCOL
+            else:
+                self._protocol = self._orientSocket.protocol
         return self._protocol
 
     def _decode_header(self):


### PR DESCRIPTION
We were trying to use Orientdb version 2.2.0-rc1 and protocol version 36 is not supported by pyorient, so the client should impose his max protocol version