### PR TITLE
Binary Deserialization support though c binding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 
 install:
 - pip install coveralls
+- pip install pyorient_native
 - "./ci/start-ci.sh $ORIENTDB_VERSION"
 
 cache:

--- a/pyorient/messages/base.py
+++ b/pyorient/messages/base.py
@@ -67,7 +67,11 @@ class BaseMessage(object):
         Lazy return of the serialization, we retrive the type from the :class: `OrientSocket <pyorient.orient.OrientSocket>` object
         :return: an Instance of the serializer suitable for decoding or encoding
         """
-        return OrientSerialization.get_impl(self._orientSocket.serialization_type)
+        if self._orientSocket.serialization_type==OrientSerialization.Binary:
+            return OrientSerialization.get_impl(self._orientSocket.serialization_type,
+                                                self._orientSocket._props)
+        else:
+            return OrientSerialization.get_impl(self._orientSocket.serialization_type)
 
     def get_orient_socket_instance(self):
         return self._orientSocket

--- a/pyorient/messages/connection.py
+++ b/pyorient/messages/connection.py
@@ -6,7 +6,7 @@ from ..constants import CONNECT_OP, FIELD_BYTE, FIELD_INT, FIELD_SHORT, \
     FIELD_STRINGS, FIELD_BOOLEAN, FIELD_STRING, NAME, SUPPORTED_PROTOCOL, \
     VERSION, SHUTDOWN_OP
 from ..utils import need_connected
-from ..serializations import OrientSerialization
+#from ..serializations import OrientSerialization
 
 #
 # Connect
@@ -19,7 +19,6 @@ class ConnectMessage(BaseMessage):
         self._user = ''
         self._pass = ''
         self._client_id = ''
-        self._serialization_type = OrientSerialization.CSV
         self._need_token = False
         self._append( ( FIELD_BYTE, CONNECT_OP ) )
 
@@ -40,11 +39,8 @@ class ConnectMessage(BaseMessage):
 
         self._append( ( FIELD_STRING, self._client_id ) )
 
-        # Set the serialization type on the shared socket object
-        self._orientSocket.serialization_type = self._serialization_type
-
         if self.get_protocol() > 21:
-            self._append( ( FIELD_STRING, self._serialization_type ) )
+            self._append( ( FIELD_STRING, self._orientSocket.serialization_type ) )
             if self.get_protocol() > 26:
                 self._append( ( FIELD_BOOLEAN, self._request_token ) )
                 if self.get_protocol() > 32:

--- a/pyorient/messages/database.py
+++ b/pyorient/messages/database.py
@@ -51,7 +51,6 @@ class DbOpenMessage(BaseMessage):
         self._client_id = ''
         self._db_name = ''
         self._db_type = DB_TYPE_DOCUMENT
-        self._serialization_type = OrientSerialization.CSV
         self._append(( FIELD_BYTE, DB_OPEN_OP ))
         self._need_token = False
 
@@ -64,8 +63,7 @@ class DbOpenMessage(BaseMessage):
                 self._pass = params[2]
                 self.set_db_type(params[3])
                 self._client_id = params[4]
-                self._serialization_type = params[5]
-
+                
             except IndexError:
                 # Use default for non existent indexes
                 pass
@@ -74,11 +72,9 @@ class DbOpenMessage(BaseMessage):
         self._append(( FIELD_SHORT, SUPPORTED_PROTOCOL ))
         self._append(( FIELD_STRING, self._client_id ))
 
-        # Set the serialization type on the shared socket object
-        self._orientSocket.serialization_type = self._serialization_type
 
         if self.get_protocol() > 21:
-            self._append(( FIELD_STRING, self._serialization_type ))
+            self._append(( FIELD_STRING, self._orientSocket.serialization_type ))
             if self.get_protocol() > 26:
                 self._append(( FIELD_BOOLEAN, self._request_token ))
                 if self.get_protocol() >= 36:
@@ -151,9 +147,6 @@ class DbOpenMessage(BaseMessage):
 
         # set database opened
         self._orientSocket.db_opened = self._db_name
-
-        # set serialization type, as global in the orient socket class
-        self._orientSocket.serialization_type = self._serialization_type
 
         return info, clusters, self._node_list
         # self._cluster_map = self._orientSocket.cluster_map = \

--- a/pyorient/ogm/config.py
+++ b/pyorient/ogm/config.py
@@ -1,6 +1,8 @@
 import os
 import re
 
+from pyorient.serializations import OrientSerialization
+
 try:
     from urllib.parse import urlparse, urlunparse
 except ImportError:
@@ -9,7 +11,7 @@ except ImportError:
 class Config(object):
     """Specifies how to connect to OrientDB server."""
     def __init__(self, host, port, user, cred, db_name=None, storage='memory'
-                 , initial_drop=False):
+                 , initial_drop=False, serialization_type=OrientSerialization.Binary):
         """
         :param initial_drop: Useful for testing; signal that any existing
         database with this configuration should be dropped on connect.
@@ -21,11 +23,11 @@ class Config(object):
         self.db_name = db_name
         self.storage = storage
         self.initial_drop = initial_drop
-
+        self.serialization_type = serialization_type
         self.scripts = None
 
     @classmethod
-    def from_url(cls, url, user, cred, initial_drop=False):
+    def from_url(cls, url, user, cred, initial_drop=False, serialization_type=OrientSerialization.CSV):
         url_exp = re.compile(r'^(\w+:\/\/)?(.*)')
         url_match = url_exp.match(url)
         if not url_match.group(1):
@@ -39,11 +41,11 @@ class Config(object):
         if url_parts.path:
             db_name = os.path.basename(url_parts.path)
             return cls(url_parts.hostname, url_parts.port, user, cred, db_name
-                       , url_parts.scheme, initial_drop)
+                       , url_parts.scheme, initial_drop, serialization_type)
         else:
             db_name = url_parts.netloc
             return cls(None, url_parts.port, user, cred, db_name
-                       , url_parts.scheme, initial_drop)
+                       , url_parts.scheme, initial_drop, serialization_type)
 
     def set_database(self, db_name, storage):
         self.db_name = db_name

--- a/pyorient/ogm/config.py
+++ b/pyorient/ogm/config.py
@@ -11,7 +11,7 @@ except ImportError:
 class Config(object):
     """Specifies how to connect to OrientDB server."""
     def __init__(self, host, port, user, cred, db_name=None, storage='memory'
-                 , initial_drop=False, serialization_type=OrientSerialization.Binary):
+                 , initial_drop=False, serialization_type=OrientSerialization.CSV):
         """
         :param initial_drop: Useful for testing; signal that any existing
         database with this configuration should be dropped on connect.

--- a/pyorient/ogm/graph.py
+++ b/pyorient/ogm/graph.py
@@ -27,7 +27,7 @@ class Graph(object):
         :note: user only meaningful when cred also provided.
         """
 
-        self.client = pyorient.OrientDB(config.host, config.port)
+        self.client = pyorient.OrientDB(config.host, config.port, config.serialization_type)
         self.client.connect(config.user, config.cred)
 
         self.config = config

--- a/pyorient/orient.py
+++ b/pyorient/orient.py
@@ -23,6 +23,31 @@ from .serializations import OrientSerialization
 
 from .utils import dlog
 
+type_map = {'BOOLEAN' :0,
+            'INTEGER' :1,
+            'SHORT' :2,
+            'LONG' :3,
+            'FLOAT' :4,
+            'DOUBLE' :5,
+            'DATETIME':6,
+            'STRING':7,
+            'BINARY':8,
+            'EMBEDDED':9,
+            'EMBEDDEDLIST':10,
+            'EMBEDDEDSET':11,
+            'EMBEDDEDMAP':12,
+            'LINK' :13,
+            'LINKLIST':14,
+            'LINKSET' :15,
+            'LINKMAP' :16,
+            'BYTE' : 17,
+            'TRANSIENT' : 18,
+            'DATE' :19,
+            'CUSTOM' : 20,
+            'DECIMAL' : 21,
+            'LINKBAG' : 22,
+            'ANY' : 23}
+
 class OrientSocket(object):
     '''Class representing the binary connection to the database, it does all the low level comunication
     And holds information on server version and cluster map
@@ -34,7 +59,7 @@ class OrientSocket(object):
     :param port: integer port of the server
 
     '''
-    def __init__(self, host, port):
+    def __init__(self, host, port, serialization_type=OrientSerialization.CSV ):
 
         self.connected = False
         self.host = host
@@ -44,8 +69,9 @@ class OrientSocket(object):
         self.session_id = -1
         self.auth_token = b''
         self.db_opened = None
-        self.serialization_type = OrientSerialization.CSV
+        self.serialization_type = serialization_type
         self.in_transaction = False
+        self._props = None
 
     def get_connection(self):
         if not self.connected:
@@ -207,9 +233,9 @@ class OrientDB(object):
         TxCommitMessage="pyorient.messages.commands",
     )
 
-    def __init__(self, host='localhost', port=2424):
+    def __init__(self, host='localhost', port=2424, serialization_type=OrientSerialization.CSV):
         if not isinstance(host, OrientSocket):
-            connection = OrientSocket(host, port)
+            connection = OrientSocket(host, port, serialization_type)
         else:
             connection = host
 
@@ -226,7 +252,8 @@ class OrientDB(object):
         self._cluster_map = None
         self._cluster_reverse_map = None
         self._connection = connection
-
+        self._serialization_type = serialization_type
+        
     def __getattr__(self, item):
 
         # No special handling for private attributes/methods.
@@ -278,13 +305,13 @@ class OrientDB(object):
 
     # SERVER COMMANDS
 
-    def connect(self, user, password, client_id='', serialization_type=OrientSerialization.CSV):
+    def connect(self, user, password, client_id=''):
         '''Connect to the server without opening any database
 
         :param user: the username of the user on the server. Example: "root"
         :param password: the password of the user on the server. Example: "37aed6392"
         :param client_id: client's id - can be null for clients. In clustered configurations it's the distributed node ID as TCP host:port
-        :param serialization_type: the serialization format required by the client, now it can be just OrientSerialization.CSV
+        ## :param serialization_type: the serialization format required by the client, now it can be just OrientSerialization.CSV
 
         Usage to open a connection as root::
 
@@ -294,7 +321,7 @@ class OrientDB(object):
 
         '''
         return self.get_message("ConnectMessage") \
-            .prepare((user, password, client_id, serialization_type)).send().fetch_response()
+            .prepare((user, password, client_id, self._serialization_type)).send().fetch_response()
 
     def db_count_records(self):
         '''Returns the number of records in the currently open database.
@@ -387,6 +414,13 @@ class OrientDB(object):
         self._reload_clusters()
         self.nodes = nodes
 
+        # store property id->property name, type map for binary serialization
+        
+        if self._serialization_type==OrientSerialization.Binary:
+            self._connection._props = {x['id']:[x['name'], type_map[x['type']]] for x in
+                        self.command("select from #0:1")[0].oRecordData['globalProperties']}
+        
+        
         return self.clusters
 
     def db_reload(self):

--- a/pyorient/serializations.py
+++ b/pyorient/serializations.py
@@ -16,10 +16,12 @@ class OrientSerializationBinary(object):
         self.data = {}
         self.type = OrientSerialization.Binary
         self.props = props
+        self._writer = None
         
     def decode(self, content):
         if not binary_support:
-            raise NotImplementedError
+            raise Exception("To support Binary Serialization,\
+                            pyorient_native must be installed")
         clsname, data = pyorient_native.deserialize(content,
                                     content.__sizeof__(), self.props)
         rels = [k for k in data.keys() if ('in_' in k or 'out_' in k
@@ -35,9 +37,15 @@ class OrientSerializationBinary(object):
         return [clsname, data]
 
     def encode(self, record):
-        raise NotImplementedError
-
-
+        if not binary_support:
+            raise Exception("To support Binary Serialization,\
+                            pyorient_native must be installed")
+        if record:
+            return pyorient_native.serialize(record)
+        else:
+            return None
+            
+            
 class OrientSerializationCSV(object):
     def __init__(self):
         self.className = None

--- a/tests/test_serializations.py
+++ b/tests/test_serializations.py
@@ -129,7 +129,8 @@ class SerializationTestCase(unittest.TestCase):
             _n_rid = cluster_id.decode()
         else:
             _n_rid = str(cluster_id)
-            
+
+        DB.command( "CREATE CLASS test EXTENDS E" )
         DB.command("create edge test from %s to %s" % ("#" + _n_rid + ":0" ,
                                                        "#" + _n_rid + ":1" ))
         rec0 = DB.record_load( "#" + _n_rid + ":0" )

--- a/tests/test_serializations.py
+++ b/tests/test_serializations.py
@@ -44,11 +44,14 @@ class SerializationTestCase(unittest.TestCase):
         DB = binary_db_connect()
         DB.command( "CREATE CLASS MyModel EXTENDS V" )[0]
         cluster_id = DB.command("select classes[name='MyModel']"+\
-                        ".defaultClusterId from 0:1")[0].oRecordData['classes']
-        data = {'key': long(-1)}
+                                ".defaultClusterId from 0:1")[0].oRecordData['classes']
+        import sys
+        if sys.version_info[0] < 3:
+            data = {'key': long(-1)}
+        else:
+            data = {'key': int(-1)}
         DB.record_create( cluster_id, {'@MyModel': data} )
 
-        import sys
         if sys.version_info[0] >= 3 and isinstance( cluster_id, bytes ):
             _n_rid = cluster_id.decode()
         else:
@@ -79,7 +82,7 @@ class SerializationTestCase(unittest.TestCase):
         cluster_id = DB.command("select classes[name='MyModel']"+\
                         ".defaultClusterId from 0:1")[0].oRecordData['classes']
         
-        data = {'key': [1,'a',long(3),4.0, [42,27]]}
+        data = {'key': [1,'a',3,4.0, [42,27]]}
         DB.record_create( cluster_id, {'@MyModel': data} )
 
         import sys
@@ -157,6 +160,8 @@ class SerializationTestCase(unittest.TestCase):
         else:
             _n_rid = str(cluster_id)
 
+            
+            
         rec = DB.record_load( "#" + _n_rid + ":0" )
         assert rec.oRecordData == data
 
@@ -169,7 +174,7 @@ class SerializationTestCase(unittest.TestCase):
         
         dt =  datetime.datetime.now()
         # OrientDB datetime has millisecond precision
-        dt = dt.replace(microsecond=(dt.microsecond/1000)*1000)
+        dt = dt.replace(microsecond=int(dt.microsecond/1000)*1000)
         data = {'key': dt}
         DB.record_create( cluster_id, {'@MyModel': data} )
 


### PR DESCRIPTION
These changes add the ability to configure the serialization protocol. The default protocol is selected to be CSV but can be changed to Binary either through the Config class or at the instantiation of OrientDB().  The underlying binary deserialization (working but not complete and not tested thoroughly) is through https://github.com/nikulukani/pyorient_native. Will work on supporting encoding soon.