### PR TITLE
Embedded default value parsing fix.

### DIFF
--- a/pyorient/serializations.py
+++ b/pyorient/serializations.py
@@ -475,7 +475,7 @@ class OrientSerializationCSV(object):
             key = chunk[0]
             content = chunk[1]
 
-        chunk = self._parse_key(content)
+        chunk = self._parse_value(content)
         value = chunk[0]
         content = chunk[1].lstrip(' ')
 

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -588,9 +588,19 @@ class OGMEmbeddedDefaultsTestCase(unittest.TestCase):
 
         node = g.DefaultEmbeddedNode.create(name='default_embedded')
         node.info = [{}]
-        node.save()
 
-        # On the next load, the node should have the mapping 'foo' -> {'normal': False} in 'info'.
+        try:
+            node.save()
+        except PyOrientCommandException as e:
+            if 'incompatible type is used.' in e.errors[0]:
+                # The current OrientDB version doesn't allow embedded classes, only primitives.
+                # Simply skip this test, there's nothing we can test here.
+                return
+            else:
+                raise
+
+        # On the next load, the node should have:
+        # 'info' = [{'normal': False}]
         node = g.DefaultEmbeddedNode.query().one()
         self.assertIn('normal', node.info[0])
         self.assertIs(node.info[0]['normal'], False)

--- a/tests/test_ogm.py
+++ b/tests/test_ogm.py
@@ -577,7 +577,7 @@ class OGMEmbeddedDefaultsTestCase(unittest.TestCase):
         g.client.command('CREATE PROPERTY DefaultData.normal Boolean')
         g.client.command('ALTER PROPERTY DefaultData.normal DEFAULT 0')
         g.client.command('CREATE PROPERTY DefaultEmbeddedNode.name String')
-        g.client.command('CREATE PROPERTY DefaultEmbeddedNode.info EmbeddedMap DefaultData')
+        g.client.command('CREATE PROPERTY DefaultEmbeddedNode.info EmbeddedList DefaultData')
 
         base_node = declarative_node()
         base_relationship = declarative_relationship()
@@ -587,13 +587,13 @@ class OGMEmbeddedDefaultsTestCase(unittest.TestCase):
         g = self.g
 
         node = g.DefaultEmbeddedNode.create(name='default_embedded')
-        node.info = {'foo': {}}
+        node.info = [{}]
         node.save()
 
         # On the next load, the node should have the mapping 'foo' -> {'normal': False} in 'info'.
         node = g.DefaultEmbeddedNode.query().one()
-        self.assertIn('normal', node.info['foo'])
-        self.assertIs(node.info['foo']['normal'], False)
+        self.assertIn('normal', node.info[0])
+        self.assertIs(node.info[0]['normal'], False)
 
 
 if sys.version_info[0] < 3:


### PR DESCRIPTION
Fixes #211.

A few of the tests do not run on old OrientDB versions because of missing functionality in that version of OrientDB, so I simply catch the resulting errors and ignore the test. I'm open to ideas if you have a cleaner solution for this problem.