### PR TITLE
Correct serialization of floating point numbers for Python 2

### DIFF
--- a/pyorient/ogm/property.py
+++ b/pyorient/ogm/property.py
@@ -98,7 +98,11 @@ class PropertyEncoder:
     @staticmethod
     def encode_value(value):
         if isinstance(value, decimal.Decimal):
-            return repr(str(value))
+            return u'"{:f}"'.format(value)
+        elif isinstance(value, float):
+            with decimal.localcontext() as ctx:
+                ctx.prec = 20  # floats are max 80-bits wide = 20 significant digits
+                return u'"{:f}"'.format(decimal.Decimal(value))
         elif isinstance(value, datetime.datetime) or isinstance(value, datetime.date):
             return u'"{}"'.format(value)
         elif isinstance(value, str):


### PR DESCRIPTION
In Python 2, using `str()` to convert `Decimal` and `float` to strings is not safe since by default, it produces scientific notation for numbers far away from 0, whereas OrientDB does not accept scientific notation.

This PR ensures that numbers are represented with as much precision as possible, and adds a test for the serialization of the values `[1e50, 1e-50, 1.23456789012]` to ensure everything works properly.