### PR TITLE
Hotfix of sockets leak for master branch

### DIFF
--- a/pyorient/orient.py
+++ b/pyorient/orient.py
@@ -59,7 +59,6 @@ class OrientSocket(object):
         '''
         dlog("Trying to connect...")
         try:
-            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self._socket.settimeout( SOCK_CONN_TIMEOUT )  # 30 secs of timeout
             self._socket.connect( (self.host, self.port) )
             _value = self._socket.recv( FIELD_SHORT['bytes'] )
@@ -226,6 +225,9 @@ class OrientDB(object):
         self._cluster_map = None
         self._cluster_reverse_map = None
         self._connection = connection
+
+    def close(self):
+        self._connection.close()
 
     def __getattr__(self, item):
 
@@ -492,7 +494,7 @@ class OrientDB(object):
                 return message_instance
 
         except KeyError as e:
-            self._connection.close()
+            self.close()
             raise PyOrientBadMethodCallException(
                 "Unable to find command " + str(e), []
             )


### PR DESCRIPTION
This fixes the issue #233.
This PR contain the same changes as #234 but this one is for `master` branch.
The changes:
- Removed opening of a socket from `OrientSocket.connect` method that had duplicated opening of a socket in `OrientSocket.__init__` method.
- Added `close` method to `OrientDB` class for closing the underlying socket.