### PR TITLE
 Remove unnecessary processing of binary deserialized data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ cache:
   - "./ci/environment/"
 
 before_script:
-- sleep 100
+- sleep 15
 - travis_retry ../ci/environment//orientdb_current/bin/console.sh "CONNECT remote:localhost root root"
   
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ cache:
   - ./docs/build/html/
   - "./ci/environment/"
 
+before_script:
+- sleep 100
+- travis_retry ../ci/environment//orientdb_current/bin/console.sh "CONNECT remote:localhost root root"
+  
 script:
 - nosetests -vv --with-coverage --cover-xml --cover-erase --cover-package=pyorient
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 
 before_script:
 - sleep 15
-- travis_retry ../ci/environment//orientdb_current/bin/console.sh "CONNECT remote:localhost root root"
+- travis_retry ./ci/environment//orientdb_current/bin/console.sh "CONNECT remote:localhost root root"
   
 script:
 - nosetests -vv --with-coverage --cover-xml --cover-erase --cover-package=pyorient

--- a/pyorient/constants.py
+++ b/pyorient/constants.py
@@ -4,7 +4,7 @@ __author__ = 'mogui <mogui83@gmail.com>'
 # Driver Constants
 #
 NAME = "OrientDB Python binary client (pyorient)"
-VERSION = "1.5.3b"
+VERSION = "1.5.5b"
 SUPPORTED_PROTOCOL = 36
 
 #

--- a/pyorient/serializations.py
+++ b/pyorient/serializations.py
@@ -23,16 +23,6 @@ class OrientSerializationBinary(object):
     def decode(self, content):
         clsname, data = pyorient_native.deserialize(content,
                                     content.__sizeof__(), self.props)
-        rels = [k for k in data.keys() if ('in_' in k or 'out_' in k
-                                       or k=='in' or k=='out')] 
-        for k in rels:
-            if isinstance(data[k],list):
-                for i in range(len(data[k])):
-                    data[k][i] = OrientRecordLink(str(data[k][i][1]) + ':' +
-                                                  str(data[k][i][2]))
-            elif isinstance(data[k],tuple):
-                data[k] = OrientRecordLink(str(data[k][1]) + ':' +
-                                                  str(data[k][2]))
         return [clsname, data]
 
     def encode(self, record):


### PR DESCRIPTION
Remove code that casted tuples of the form ('OrientRecordLink', <clusterID>, <recordPosition>) to pyorient.otypes.OrientRecordLink as pyorient_native now creates instances of OrientRecordLink directly. (nikulukani/pyorient_native#2)