### PR TITLE
Develop : OGM fix for using is operator in where clause where value is null

### DIFF
--- a/pyorient/ogm/property.py
+++ b/pyorient/ogm/property.py
@@ -106,6 +106,16 @@ class PropertyEncoder:
         return name
 
     @staticmethod
+    def encode_operator(value):
+        """Encode the correct SQL operator based on the value"""
+
+        # If the value is "None" (SQL null) use " is " all other cases use " = "
+        if value is None:
+            return u' is '
+        else:
+            return u' = '
+
+    @staticmethod
     def encode_value(value, expressions):
         from pyorient.ogm.what import What
 
@@ -227,4 +237,3 @@ class PreOp(object):
         :param attr: Name of attribute specifying PreOp
         """
         pass
-

--- a/pyorient/ogm/query.py
+++ b/pyorient/ogm/query.py
@@ -107,7 +107,7 @@ class Query(RetrievalCommand, CacheMixin):
 
         new_query = self.from_string(self.compile().format(*[encode(arg) for arg in args], **{k:encode(v) for k,v in kwargs.items()}), self._graph)
         new_query.source_name = self.source_name
-        new_query._class_props = self._class_props 
+        new_query._class_props = self._class_props
         new_query._params = self._params
         return new_query
 
@@ -527,7 +527,8 @@ class Query(RetrievalCommand, CacheMixin):
             (u'(' + str(v) + ')' if isinstance(v, RetrievalCommand) else self.build_what(v))
 
     def build_assign_vertex(self, k, v):
-        return PropertyEncoder.encode_name(k) + u' = ' + \
+        return PropertyEncoder.encode_name(k) + \
+            PropertyEncoder.encode_operator(v) + \
             ArgConverter.convert_to(ArgConverter.Vertex, v, self)
 
     def build_lets(self, params):
@@ -733,4 +734,3 @@ class TempParams(object):
                 del self.params[k]
             else:
                 self.params[k] = v
-


### PR DESCRIPTION
Fix for issue #262 :OGM: NULL fields not queried correctly

Added test case DictBasicQueryTest.

Added encode_operator() method to PropertyEncoder.

Updated build_assign_vertex() method in Query to call encode_operator().