### PR TITLE
chore: change the verison of orientdb-community.

### DIFF
--- a/ci/start-ci.sh
+++ b/ci/start-ci.sh
@@ -3,7 +3,7 @@ set -e
 
 PARENT_DIR=$(dirname $(cd "$(dirname "$0")"; pwd))
 CI_DIR="$PARENT_DIR/ci/environment"
-DEFAULT_ORIENT_VERSION="2.1.5"
+DEFAULT_ORIENT_VERSION="2.2.33"
 
 # launch simple instance in debug mode with shell hang up
 while [ $# -ne 0 ]; do


### PR DESCRIPTION
Keep up with the OrientDB community.

2.1.5 is out of data. use 2.2.33.

