### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyorient/hexdump.py
+++ b/pyorient/hexdump.py
@@ -95,7 +95,7 @@ PY3K = sys.version_info >= (3, 0)
 def chunks(seq, size):
     """Generator that cuts sequence (bytes, memoryview, etc.)
        into chunks of given size. If `seq` length is not multiply
-       of `size`, the lengh of the last chunk returned will be
+       of `size`, the length of the last chunk returned will be
        less than requested.
 
        >>> list( chunks([1,2,3,4,5,6,7], 3) )

--- a/pyorient/messages/base.py
+++ b/pyorient/messages/base.py
@@ -64,7 +64,7 @@ class BaseMessage(object):
 
     def get_serializer(self):
         """
-        Lazy return of the serialization, we retrive the type from the :class: `OrientSocket <pyorient.orient.OrientSocket>` object
+        Lazy return of the serialization, we retrieve the type from the :class: `OrientSocket <pyorient.orient.OrientSocket>` object
         :return: an Instance of the serializer suitable for decoding or encoding
         """
         if self._orientSocket.serialization_type==OrientSerialization.Binary:

--- a/pyorient/orient.py
+++ b/pyorient/orient.py
@@ -49,7 +49,7 @@ type_map = {'BOOLEAN' :0,
             'ANY' : 23}
 
 class OrientSocket(object):
-    '''Class representing the binary connection to the database, it does all the low level comunication
+    '''Class representing the binary connection to the database, it does all the low level communication
     And holds information on server version and cluster map
 
     .. DANGER::
@@ -438,7 +438,7 @@ class OrientDB(object):
     def update_properties(self):
         '''
         This method fetches the global Properties from the server. The properties are used
-        for deserializing based on propery index if using binary serialization. This method
+        for deserializing based on property index if using binary serialization. This method
         should be called after any manual command that may result in modifications to the
         properties table, for example, "Create property ... " or "Create class .." followed
         by "Create vertex set ... "

--- a/pyorient/otypes.py
+++ b/pyorient/otypes.py
@@ -246,9 +246,9 @@ class OrientNode(object):
         """
         Represent a server node in a multi clusered configuration
 
-        TODO: extends this object with different listeners if we're going to support in the driver an abstarction of the HTTP protocol, for now we are not interested in that
+        TODO: extends this object with different listeners if we're going to support in the driver an abstraction of the HTTP protocol, for now we are not interested in that
 
-        :param node_dict: dict with starting configs (usaully from a db_open, db_reload record response)
+        :param node_dict: dict with starting configs (usually from a db_open, db_reload record response)
         """
         #: node name
         self.name = None


### PR DESCRIPTION
There are small typos in:
- pyorient/hexdump.py
- pyorient/messages/base.py
- pyorient/orient.py
- pyorient/otypes.py

Fixes:
- Should read `usually` rather than `usaully`.
- Should read `retrieve` rather than `retrive`.
- Should read `property` rather than `propery`.
- Should read `length` rather than `lengh`.
- Should read `communication` rather than `comunication`.
- Should read `abstraction` rather than `abstarction`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md